### PR TITLE
Fix issue#4, "flake8 not found" OS X #4

### DIFF
--- a/defaultPreferences.js
+++ b/defaultPreferences.js
@@ -12,7 +12,7 @@ define(function (require, exports, module) {
         "msysflake8Path":                     null
     };
 
-    defaultPreferences.flake8IsInSystemPath = true;
+    defaultPreferences.flake8IsInSystemPath = false;
     defaultPreferences.flake8Path           = "/usr/bin/flake8";
 
     module.exports = defaultPreferences;


### PR DESCRIPTION
flake8 extension always complain about "flake8 not found", this is due to flake8 by default is not in the system path of OS X, so change this setting default to false will get rid of the pain of Mac OS X user. And pep8 extension set the pep8InSystemPath = false too.
